### PR TITLE
Prefix list decorator

### DIFF
--- a/examples/add_prefix_list_researcher.py
+++ b/examples/add_prefix_list_researcher.py
@@ -14,6 +14,4 @@ iblaws.utils.ec2_update_managed_prefix_list_item(
 )
 
 # %% If the entry doesn not exist:
-iblaws.utils.ec2_add_managed_prefix_list_item(
-ec2, managed_prefix_list_id=PREFIX_LIST_ID, description=description, cidrip=new_ip
-)
+iblaws.utils.ec2_add_managed_prefix_list_item(ec2, managed_prefix_list_id=PREFIX_LIST_ID, description=description, cidrip=new_ip)

--- a/examples/update_prefix_list_devs.py
+++ b/examples/update_prefix_list_devs.py
@@ -2,9 +2,11 @@ from pathlib import Path
 import iblaws.utils
 import requests
 
+
 def get_public_ip():
     response = requests.get('https://api.ipify.org')
     return response.text
+
 
 PREFIX_LIST_ID = 'pl-05d04791174282256'
 description = 'Olivier (mobile)'

--- a/examples/update_security_group_rule.py
+++ b/examples/update_security_group_rule.py
@@ -1,16 +1,13 @@
 """
-DEPRECATED: we use prefix lists for staff and researchers
+This is the way to change the access for lightning AI
+Right now it is set to a single IP address for spike sorting testing
 """
 
-from pathlib import Path
 import iblaws.utils
 
 # EC2 instance details
-INSTANCE_ID = 'i-05c9c8e9cca199cc7'
-KEY_PAIR_PATH = Path.home().joinpath('spikesorting_rerun.pem')
-USERNAME = 'ubuntu'  # This might be different based on your AMI
 security_group_id = 'sg-0ec7c3c71eba340dd'
-security_group_rule = 'sgr-03801255f4bb69acc'
-new_ip = '98.84.125.97/32'
+security_group_rule = 'sgr-04ec3987392de2ac2'
+new_ip = '3.87.210.184/32'
 ec2 = iblaws.utils.get_service_client(service_name='ec2', region_name='eu-west-2')
 iblaws.utils.ec2_update_security_group_rule(ec2, security_group_id, security_group_rule, new_ip)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,8 @@ dependencies = [
     "paramiko",
     "iblutil",
     "pydantic",
+    "pytest",
+    "pytest-mock",
 ]
 
 requires-python = ">=3.10"

--- a/src/iblaws/compute.py
+++ b/src/iblaws/compute.py
@@ -20,9 +20,13 @@ def _get_public_ip():
     return response.text
 
 
-def manage_firewall_access(worker_id):
+def manage_firewall_access(worker=0):
     def decorator(func):
         def wrapper(*args, **kwargs):
+            if 'worker_id' in kwargs:
+                worker_id = kwargs.pop('worker_id')
+            else:
+                worker_id = worker
             # run before
             description = f'Lightning AI Worker #{worker_id:02}'
             ec2 = iblaws.utils.get_service_client(service_name='ec2', region_name='eu-west-2')

--- a/src/iblaws/utils.py
+++ b/src/iblaws/utils.py
@@ -163,13 +163,11 @@ def ec2_remove_managed_prefix_list_item(ec2_client, managed_prefix_list_id: str,
         if len(close_matches) == 1:
             suggestion = f' Did you mean "{close_matches[0]}"?'
         elif len(close_matches) > 1:
-            suggestion = f' Did you mean one of these: ' + ", ".join([f'"{m}"' for m in close_matches]) + '?'
+            suggestion = f' Did you mean one of these: ' + ', '.join([f'"{m}"' for m in close_matches]) + '?'
         else:
             suggestion = ''
 
-        raise ValueError(
-            f'The description "{description}" was not found in the existing entries.' + suggestion
-        )
+        raise ValueError(f'The description "{description}" was not found in the existing entries.' + suggestion)
 
     remove_entries = [x for x in existing_entries if x['Description'] == description]
     if len(remove_entries) > 0:

--- a/src/tests/test_compute.py
+++ b/src/tests/test_compute.py
@@ -16,7 +16,7 @@ def test_manage_firewall_access_removes_ip_after_execution(mocker):
     mock_add = mocker.patch('iblaws.utils.ec2_add_managed_prefix_list_item')
 
     # Create a test function to decorate
-    @iblaws.compute.manage_firewall_access(worker_id=42)
+    @iblaws.compute.manage_firewall_access(worker=42)
     def test_function():
         return 'result'
 
@@ -54,12 +54,12 @@ def test_manage_firewall_access_adds_ip_to_prefix_list(mocker):
     mock_add_prefix_item = mocker.patch('iblaws.utils.ec2_add_managed_prefix_list_item')
 
     # Create a test function and apply the decorator
-    @iblaws.compute.manage_firewall_access(worker_id=42)
+    @iblaws.compute.manage_firewall_access()
     def test_function():
         return 'test result'
 
     # Execute the decorated function
-    result = test_function()
+    result = test_function(worker_id=42)
 
     # Verify the decorator behavior
     mock_get_public_ip.assert_called_once()

--- a/src/tests/test_compute.py
+++ b/src/tests/test_compute.py
@@ -1,0 +1,75 @@
+import iblaws.compute
+import pytest
+
+
+def test_manage_firewall_access_removes_ip_after_execution(mocker):
+    # Mock the AWS service client
+    mock_ec2 = mocker.Mock()
+    mock_get_service_client = mocker.patch('iblaws.utils.get_service_client', return_value=mock_ec2)
+
+    # Mock the IP getter
+    mock_public_ip = '123.45.67.89'
+    mocker.patch('iblaws.compute._get_public_ip', return_value=mock_public_ip)
+
+    # Mock the EC2 utility functions
+    mock_remove = mocker.patch('iblaws.utils.ec2_remove_managed_prefix_list_item')
+    mock_add = mocker.patch('iblaws.utils.ec2_add_managed_prefix_list_item')
+
+    # Create a test function to decorate
+    @iblaws.compute.manage_firewall_access(worker_id=42)
+    def test_function():
+        return 'result'
+
+    # Call the decorated function
+    result = test_function()
+
+    # Verify the function was executed correctly
+    assert result == 'result'
+
+    # Verify AWS client was initialized properly
+    mock_get_service_client.assert_called_once_with(service_name='ec2', region_name='eu-west-2')
+
+    # Check that the IP was added before execution
+    mock_add.assert_called_once_with(
+        mock_ec2,
+        managed_prefix_list_id=iblaws.compute.HTTPS_PREFIX_LIST_ID,
+        description='Lightning AI Worker #42',
+        cidrip=f'{mock_public_ip}/32',
+    )
+
+    # Verify the IP was removed after execution (which is the main purpose of this test)
+    assert mock_remove.call_count == 2  # Called once before (try block) and once after execution
+    mock_remove.assert_called_with(
+        mock_ec2, managed_prefix_list_id=iblaws.compute.HTTPS_PREFIX_LIST_ID, description='Lightning AI Worker #42'
+    )
+
+
+def test_manage_firewall_access_adds_ip_to_prefix_list(mocker):
+    # Mock dependencies
+    mock_get_public_ip = mocker.patch('iblaws.compute._get_public_ip', return_value='192.168.1.1')
+    mock_get_service_client = mocker.patch('iblaws.utils.get_service_client')
+    mock_ec2 = mocker.MagicMock()
+    mock_get_service_client.return_value = mock_ec2
+    mock_remove_prefix_item = mocker.patch('iblaws.utils.ec2_remove_managed_prefix_list_item')
+    mock_add_prefix_item = mocker.patch('iblaws.utils.ec2_add_managed_prefix_list_item')
+
+    # Create a test function and apply the decorator
+    @iblaws.compute.manage_firewall_access(worker_id=42)
+    def test_function():
+        return 'test result'
+
+    # Execute the decorated function
+    result = test_function()
+
+    # Verify the decorator behavior
+    mock_get_public_ip.assert_called_once()
+    mock_get_service_client.assert_called_once_with(service_name='ec2', region_name='eu-west-2')
+    mock_remove_prefix_item.assert_called()
+    mock_add_prefix_item.assert_called_once_with(
+        mock_ec2,
+        managed_prefix_list_id=iblaws.compute.HTTPS_PREFIX_LIST_ID,
+        description='Lightning AI Worker #42',
+        cidrip='192.168.1.1/32',
+    )
+    assert result == 'test result'
+    assert mock_remove_prefix_item.call_count == 2  # Called before and after


### PR DESCRIPTION
For  automation of re-run, create a decorator that will update the firewall.
Specific credentials can be used in the studio that have a reduced scope.

Closes #3 